### PR TITLE
Add missing radiosonde module in MacOS and Windows builds

### DIFF
--- a/make_macos_bundle.sh
+++ b/make_macos_bundle.sh
@@ -65,6 +65,9 @@ bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/misc_modules/f
 bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/misc_modules/recorder/recorder.dylib
 bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/misc_modules/rigctl_server/rigctl_server.dylib
 bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/misc_modules/scanner/scanner.dylib
+bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/misc_modules/bookmark_manager/bookmark_manager.dylib
+
+
 
 # ========================= Finalize =========================
 

--- a/make_macos_bundle.sh
+++ b/make_macos_bundle.sh
@@ -56,6 +56,7 @@ bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/sink_modules/n
 # Decoder modules
 bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/decoder_modules/m17_decoder/m17_decoder.dylib
 bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/decoder_modules/meteor_demodulator/meteor_demodulator.dylib
+bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/decoder_modules/sdrpp_radiosonde/sdrpp_radiosonde.dylib
 bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/decoder_modules/radio/radio.dylib
 
 # Misc modules

--- a/make_macos_bundle.sh
+++ b/make_macos_bundle.sh
@@ -56,7 +56,7 @@ bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/sink_modules/n
 # Decoder modules
 bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/decoder_modules/m17_decoder/m17_decoder.dylib
 bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/decoder_modules/meteor_demodulator/meteor_demodulator.dylib
-bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/decoder_modules/sdrpp_radiosonde/sdrpp_radiosonde.dylib
+bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/decoder_modules/sdrpp_radiosonde/radiosonde_decoder.dylib
 bundle_install_binary $BUNDLE $BUNDLE/Contents/Plugins $BUILD_DIR/decoder_modules/radio/radio.dylib
 
 # Misc modules

--- a/make_windows_package.ps1
+++ b/make_windows_package.ps1
@@ -66,7 +66,7 @@ cp "C:/Program Files/codec2/lib/libcodec2.dll" sdrpp_windows_x64/
 
 cp $build_dir/decoder_modules/meteor_demodulator/Release/meteor_demodulator.dll sdrpp_windows_x64/modules/
 
-cp $build_dir/decoder_modules/sdrpp_radiosonde/Release/sdrpp_radiosonde.dll sdrpp_windows_x64/modules/
+cp $build_dir/decoder_modules/sdrpp_radiosonde/Release/radiosonde_decoder.dll sdrpp_windows_x64/modules/
 
 cp $build_dir/decoder_modules/radio/Release/radio.dll sdrpp_windows_x64/modules/
 

--- a/make_windows_package.ps1
+++ b/make_windows_package.ps1
@@ -82,6 +82,8 @@ cp $build_dir/misc_modules/rigctl_server/Release/rigctl_server.dll sdrpp_windows
 
 cp $build_dir/misc_modules/scanner/Release/scanner.dll sdrpp_windows_x64/modules/
 
+cp $build_dir/misc_modules/bookmark_manager/Release/bookmark_manager.dll sdrpp_windows_x64/modules/
+
 
 # Copy supporting libs
 cp 'C:/Program Files/PothosSDR/bin/libusb-1.0.dll' sdrpp_windows_x64/

--- a/make_windows_package.ps1
+++ b/make_windows_package.ps1
@@ -66,6 +66,8 @@ cp "C:/Program Files/codec2/lib/libcodec2.dll" sdrpp_windows_x64/
 
 cp $build_dir/decoder_modules/meteor_demodulator/Release/meteor_demodulator.dll sdrpp_windows_x64/modules/
 
+cp $build_dir/decoder_modules/sdrpp_radiosonde/Release/sdrpp_radiosonde.dll sdrpp_windows_x64/modules/
+
 cp $build_dir/decoder_modules/radio/Release/radio.dll sdrpp_windows_x64/modules/
 
 


### PR DESCRIPTION
Fixes issue #4. 

The main problem is that the MacOS and Windows builds have a static list of libs that they copy into the release package, rather than doing it dynamically based on what was actually built. Hence, need to manually add any modules we add to this repo to both OSes.